### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/ghe-cross-instance-committers/security/code-scanning/2](https://github.com/advanced-security/ghe-cross-instance-committers/security/code-scanning/2)

To fix this problem, explicitly declare a `permissions` block within the workflow file. Since the workflow does not appear to need write access to GitHub resources—such as pull requests, issues, or repository contents—the recommended minimal permissions are `contents: read`, ensuring jobs only have read access to repository data. This should be placed either at the top level of the workflow (to apply to all jobs), or under the individual `build` job. The simplest, most maintainable approach is to add it at the root of the workflow, directly after the `name:` and before `on:`.

No new methods or imports are needed; the change is only to the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
